### PR TITLE
allow empty logo

### DIFF
--- a/pyxtream/pyxtream.py
+++ b/pyxtream/pyxtream.py
@@ -212,8 +212,8 @@ class Episode:
         self.episode_number = episode_info["episode_num"]
         self.av_info = episode_info["info"]
 
-        self.logo = series_info["cover"]
-        self.logo_path = xtream._get_logo_local_path(self.logo)
+        self.logo = series_info.get("cover", "")
+        self.logo_path = xtream._get_logo_local_path(self.logo) if len(self.logo) > 0 else ""
 
         self.url = f"{xtream.server}/series/" \
                    f"{xtream.authorization['username']}/" \


### PR DESCRIPTION
I noticed that this library did not work for me - it was due to missing covers. I assume some providers do not set/use the cover, so I've added this simple check.

Thank you for creating this! I really like the way this works, also with the progress bars while reading the groups, really nice!