### PR TITLE
make sure episodes get added to correct seasons

### DIFF
--- a/pyxtream/pyxtream.py
+++ b/pyxtream/pyxtream.py
@@ -1023,6 +1023,11 @@ class XTream:
             get_series.seasons[season_name] = season
             if "episodes" in series_seasons.keys():
                 for series_season in series_seasons["episodes"].keys():
+                    # add only episodes of current season
+                    # use series_season as fallback to make sure episodes will be set
+                    # if we can not parse the season number
+                    if int(series_info.get('season_number', series_season)) != int(series_season):
+                        continue
                     for episode_info in series_seasons["episodes"][str(series_season)]:
                         new_episode_channel = Episode(
                             self, series_info, "Testing", episode_info


### PR DESCRIPTION
While testing I noticed that all episodes were added to the Series class. So season 01 would also have episode S02E01, etc.
I found this was due to an iteration over all series which would add all episodes the each season.
I added this simple check, which also has some kind of fallback to mimic the old behaviour. If the season number can not be read for whatever reason, I simply add all episodes to the current season (like before). I'm not sure if thats a valid use case which might happen, so I don't know if thats required.